### PR TITLE
some cleanup

### DIFF
--- a/JellyCarWorlds.asl
+++ b/JellyCarWorlds.asl
@@ -1,6 +1,7 @@
 state("JellyCar Worlds") {}
 
-startup {
+startup
+{
     settings.Add("split_levelexit", true, "Split on each level exit");
     settings.Add("split_worldexit", true, "Split on each world exit");
 
@@ -25,17 +26,14 @@ init {
 
 update
 {
-    if (vars.Helper.Scenes.Active.Name != null)
-    {
-        current.SceneName = vars.Helper.Scenes.Active.Name;
-    }
+    current.SceneName = vars.Helper.Scenes.Active.Name ?? old.SceneName;
 }
 
 start
 {
     if (current.SceneName == "game" && old.SceneName == "newgame")
     {
-        print("Start");
+        vars.Log("Start");
         return true;
     }
 }
@@ -44,20 +42,21 @@ reset
 {
     if (current.SceneName == "newgame" && old.SceneName == "menus")
     {
-        print("Reset");
+        vars.Log("Reset");
         return true;
     }
 }
 
 split
 {
-    if (vars.Helper["LevelIsComplete"].Current &! vars.Helper["LevelIsComplete"].Old)
+    if (current.LevelIsComplete && !old.LevelIsComplete)
     {
-        if (settings["split_worldexit"] && vars.Helper["ActiveLevelType"].Current == 0)
+        if (settings["split_worldexit"] && current.ActiveLevelType == 0)
         {
             return true;
         }
-        if (settings["split_levelexit"] && vars.Helper["ActiveLevelType"].Current == 1)
+
+        if (settings["split_levelexit"] && current.ActiveLevelType == 1)
         {
             return true;
         }

--- a/JellyCarWorlds.asl
+++ b/JellyCarWorlds.asl
@@ -9,7 +9,8 @@ startup
     vars.Helper.LoadSceneManager = true;
 }
 
-init {
+init
+{
     vars.Helper.TryLoad = (Func<dynamic, bool>)(mono =>
     {
         var ujc = mono["UtilsJellyCar"];


### PR DESCRIPTION
Makes use of some more asl-help features.

The `start`, `split`, and `reset` blocks could be shortened to a single line each, but I refrained from doing that here.